### PR TITLE
Plugin refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE            ?= $(REGISTRY)/$(ORG)/kore
 BUILD_DIR        = "${GOPATH}/src/github.com/hegemone/kore/build"
 SOURCES          := $(shell find . -name '*.go' -not -path "*/vendor/*" -not -path "*/extensions/*")
 TEST_SOURCES	 := $(shell go list ./... | grep -v extension)
-PROJECT_ROOT := ""$(abspath $(lastword $(MAKEFILE_LIST)))/..""
+PROJECT_ROOT := $(abspath $(lastword $(MAKEFILE_LIST)))/..
 .DEFAULT_GOAL    := build
 
 vendor:

--- a/pkg/comm/adapter.go
+++ b/pkg/comm/adapter.go
@@ -19,84 +19,37 @@ var adapterCmdRegexp, _ = regexp.Compile(fmt.Sprintf("^%s\\S*($| )",
 // Similar to the `Plugin`, it is a facade type that delegates  actions like
 // sending and receiving messages to concrete implementations dynamically loaded
 // from shared libraries.
-type Adapter struct {
-	Name string
-
-	fnInit        func()
-	fnSendMessage func(string)
-	fnName        func() string
-	fnListen      func(chan<- RawIngressMessage)
-}
-
-// Listen is the public trigger that initiates an adapter to start listening
-// to external platform events. It should be implemented as non-blocking and
-// push `RawIngressMessage`s to the inChan on the receipt of raw messages
-// from the external platform.
-func (a *Adapter) Listen(inChan chan<- RawIngressMessage) {
-	// Possibly some common logic an Adapter might want to do instead of having
-	// the engine call the raw plugin listen directly
-	// NOTE: Engine has already handled spawning the listen routines in their
-	// own goroutines, so they're running concurrently and/or in parallel.
-	// TODO: Engine probably needs to handle the case of adapters being poorly
-	// written and immediately having their channels close or leaked. fnListen
-	// is expected to be long lived.
-	a.fnListen(inChan)
-}
-
-// SendMessage is the public trigger indicating a dynamically loaded adapter
-// should transmit an `EgressMessage` to its platform. Dynamically loaded
-// adapters must define how that is done.
-func (a *Adapter) SendMessage(emsg EgressMessage) {
-	// TODO: General processing
-	a.fnSendMessage(emsg.Serialize())
+type Adapter interface {
+	// SendMessage is the public trigger indicating a dynamically loaded adapter
+	// should transmit an `EgressMessage` to its platform. Dynamically loaded
+	// adapters must define how that is done.
+	SendMessage(EgressMessage)
+	Name() string
+	// Listen is the public trigger that initiates an adapter to start listening
+	// to external platform events. It should be implemented as non-blocking and
+	// push `RawIngressMessage`s to the inChan on the receipt of raw messages
+	// from the external platform.
+	Listen(chan<- RawIngressMessage)
 }
 
 // LoadAdapter loads adapter behavior from a given .so adapter file
-func LoadAdapter(adapterFile string) (*Adapter, error) {
+func LoadAdapter(adapterFile string) (Adapter, error) {
 	// TODO: Need a *lot* of validation here to make sure a bad adapter doesn't
 	// just crash the server.
 	// -> Actually confirm the casts are valid and these functions look like they should?
 	// TODO: Can the hardcoded pattern of $PROPERTY Lookup -> Cast be made more elegant?
-	a := Adapter{}
-
 	rawGoPlugin, err := goplugin.Open(adapterFile)
 	if err != nil {
 		return nil, err
 	}
 
-	nameSym, err := rawGoPlugin.Lookup("Name")
+	aSym, err := rawGoPlugin.Lookup("Adapter")
 	if err != nil {
 		return nil, err
 	}
-	a.fnName = nameSym.(func() string)
-	a.Name = a.fnName()
+	a := aSym.(Adapter)
 
-	listenSym, err := rawGoPlugin.Lookup("Listen")
-	if err != nil {
-		return nil, err
-	}
-	a.fnListen = listenSym.(func(chan<- RawIngressMessage))
-
-	sendMessageSym, err := rawGoPlugin.Lookup("SendMessage")
-	if err != nil {
-		return nil, err
-	}
-	a.fnSendMessage = sendMessageSym.(func(string))
-
-	initSym, err := rawGoPlugin.Lookup("Init")
-	if err != nil {
-		return nil, err
-	}
-	a.fnInit = initSym.(func())
-
-	return &a, nil
-}
-
-// Init gives adapters an opportunity to implement an initialization hook.
-// Typically used for things like setting up initial connection to external
-// platform APIs, checking for the presence of credentials and their validity, etc.
-func (a *Adapter) Init() {
-	a.fnInit()
+	return a, nil
 }
 
 func isCmd(rawContent string) bool {

--- a/pkg/comm/engine.go
+++ b/pkg/comm/engine.go
@@ -45,11 +45,19 @@ func (e *Engine) LoadExtensions() error {
 	if err := e.loadPlugins(); err != nil {
 		return err
 	}
-	if err := e.loadAdapters(); err != nil {
-		return err
-	}
-	return nil
+	return e.loadAdapters()
 }
+
+// These are all helper functions to allow for testing. I'll need to look
+// into if there isn't a better way to structure the code to make testing
+// easier but for now, this'll do.
+var (
+	aListen           = (*Adapter).Listen
+	eHandleRawIngress = (*Engine).handleRawIngress
+	eHandleIngress    = (*Engine).handleIngress
+	eHandleEgress     = (*Engine).handleEgress
+	funcDone          = func() {}
+)
 
 // Start will cause the engine to start listening on all successfully loaded
 // adapters. On the receipt of any new message from an adapter, it will parse
@@ -68,7 +76,7 @@ func (e *Engine) Start() {
 		go func(adapter *Adapter, adapterCh chan RawIngressMessage) {
 			// Tell the adapter to start listening and sending messages back via
 			// their own ingress channel. Listen should be non-blocking!
-			adapter.Listen(adapterCh)
+			aListen(adapter, adapterCh)
 
 			// Engine listens to the N channels the adapters are transmitting on
 			// for RawIngressMessages. Adapter channels are fanned-in to the
@@ -83,20 +91,23 @@ func (e *Engine) Start() {
 	for {
 		select {
 		case m := <-e.rawIngressBuffer:
-			e.handleRawIngress(m)
+			eHandleRawIngress(e, m)
+			funcDone()
 		case m := <-e.ingressBuffer:
-			e.handleIngress(m)
+			eHandleIngress(e, m)
+			funcDone()
 		case m := <-e.egressBuffer:
-			e.handleEgress(m)
+			eHandleEgress(e, m)
+			funcDone()
 		}
 	}
 }
 
 // Buffer messages are internal messaging types usually containing a public
 // payload + some kind of metadata, ex: to facilitate routing
-
 type rawIngressBufferMsg struct {
-	AdapterName       string
+	AdapterName string // e.g. Discord
+	// the raw message, i.e. `!cmdTrigger cmd `
 	RawIngressMessage RawIngressMessage
 }
 
@@ -144,10 +155,11 @@ func (e *Engine) handleRawIngress(m rawIngressBufferMsg) {
 	}()
 }
 
+// parseRawContent takes in the entire command string and strips off the command
+// symbol. In the case of the original Showbot, this would be `!`. It's possible
+// in the future that this function will do more processing to aid in message
+// routing.
 func parseRawContent(rawContent string) string {
-	// NOTE: It's possible in the future we'll want more processing of the raw content
-	// some kind of metadata that might be useful for the engine to route the cmd
-	// to the plugin. for now
 	return rawContent[1:len(rawContent)]
 }
 
@@ -245,7 +257,7 @@ func (e *Engine) loadPlugins() error {
 	}
 
 	log.Info("Successfully loaded plugins:")
-	for pluginName, _ := range e.plugins {
+	for pluginName := range e.plugins {
 		log.Infof("-> %s", pluginName)
 	}
 
@@ -283,7 +295,7 @@ func (e *Engine) loadAdapters() error {
 	}
 
 	log.Info("Successfully loaded adapters:")
-	for adapterName, _ := range e.adapters {
+	for adapterName := range e.adapters {
 		log.Infof("-> %s", adapterName)
 	}
 	return nil

--- a/pkg/comm/engine.go
+++ b/pkg/comm/engine.go
@@ -71,7 +71,7 @@ func (e *Engine) Start() {
 
 	// Spawn listening routines for each adapter
 	for _, adapter := range e.adapters {
-		adapterCh := make(chan RawIngressMessage)
+		adapterCh := make(chan RawIngressMessage, 1)
 
 		go func(adapter *Adapter, adapterCh chan RawIngressMessage) {
 			// Tell the adapter to start listening and sending messages back via
@@ -83,6 +83,7 @@ func (e *Engine) Start() {
 			// rawIngressBuffer for parsing.
 			for rim := range adapterCh {
 				e.rawIngressBuffer <- rawIngressBufferMsg{adapter.Name, rim}
+				funcDone()
 			}
 		}(adapter, adapterCh)
 	}

--- a/pkg/comm/engine_test.go
+++ b/pkg/comm/engine_test.go
@@ -14,6 +14,17 @@ func TestStart(t *testing.T) {
 		adapters:         make(map[string]*Adapter),
 	}
 
+	e.adapters["test"] = &Adapter{Name: "test"}
+
+	sleep := make(chan bool)
+	funcDone = func() {
+		sleep <- true
+	}
+
+	aListen = func(adapter *Adapter, inChan chan<- RawIngressMessage) {
+		inChan <- RawIngressMessage{}
+	}
+
 	HRICalled, HICalled, HECalled := false, false, false
 	eHandleRawIngress = func(*Engine, rawIngressBufferMsg) {
 		HRICalled = true
@@ -25,13 +36,11 @@ func TestStart(t *testing.T) {
 		HECalled = true
 	}
 
-	sleep := make(chan bool)
-
-	funcDone = func() {
-		sleep <- true
-	}
-
 	go e.Start()
+
+	m := <-e.rawIngressBuffer
+	t.Logf("Received message %v from ingress buffer", m)
+	<-sleep
 
 	e.rawIngressBuffer <- rawIngressBufferMsg{}
 	<-sleep

--- a/pkg/comm/engine_test.go
+++ b/pkg/comm/engine_test.go
@@ -1,0 +1,69 @@
+package comm
+
+import (
+	"testing"
+)
+
+func TestStart(t *testing.T) {
+	bufferSize := 8
+	e := &Engine{
+		rawIngressBuffer: make(chan rawIngressBufferMsg, bufferSize),
+		ingressBuffer:    make(chan ingressBufferMsg, bufferSize),
+		egressBuffer:     make(chan egressBufferMsg, bufferSize),
+		plugins:          make(map[string]*Plugin),
+		adapters:         make(map[string]*Adapter),
+	}
+
+	HRICalled, HICalled, HECalled := false, false, false
+	eHandleRawIngress = func(*Engine, rawIngressBufferMsg) {
+		HRICalled = true
+	}
+	eHandleIngress = func(*Engine, ingressBufferMsg) {
+		HICalled = true
+	}
+	eHandleEgress = func(*Engine, egressBufferMsg) {
+		HECalled = true
+	}
+
+	sleep := make(chan bool)
+
+	funcDone = func() {
+		sleep <- true
+	}
+
+	go e.Start()
+
+	e.rawIngressBuffer <- rawIngressBufferMsg{}
+	<-sleep
+	e.ingressBuffer <- ingressBufferMsg{}
+	<-sleep
+	e.egressBuffer <- egressBufferMsg{}
+	<-sleep
+
+	if !HRICalled {
+		t.Errorf("handleRawIngress was not called")
+	}
+	if !HICalled {
+		t.Errorf("handleIngress was not called")
+	}
+	if !HECalled {
+		t.Errorf("handleEgress was not called")
+	}
+	funcDone = func() {}
+}
+
+func TestParseRawContent(t *testing.T) {
+	tests := []struct {
+		raw    string
+		parsed string
+	}{
+		{"!bacon Hello world", "bacon Hello world"},
+		{"!die What's up, Doc?", "die What's up, Doc?"},
+	}
+
+	for _, test := range tests {
+		if parsed := parseRawContent(test.raw); parsed != test.parsed {
+			t.Errorf("parseRawContent(%s) = %s; wanted %s", test.raw, parsed, test.parsed)
+		}
+	}
+}

--- a/pkg/extension/adapter/discord.go
+++ b/pkg/extension/adapter/discord.go
@@ -7,14 +7,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// pkg level client reference
 type adapter struct {
 	client mock.PlatformClient
 }
-
-////////////////////////////////////////////////////////////////////////////////
-// Concrete Behavioral Implementations
-////////////////////////////////////////////////////////////////////////////////
 
 func (a *adapter) Name() string {
 	return "discord"
@@ -40,4 +35,5 @@ func (a *adapter) SendMessage(m comm.EgressMessage) {
 	a.client.SendMessage(m.Serialize())
 }
 
+// Adapter is the exported plugin symbol picked up by the engine
 var Adapter adapter


### PR DESCRIPTION
Starting work on refactoring the adapter and plugin interfaces.

This changes the adapters to use a common interface and removes the need for an adapter struct type in the engine.

As long as an adapter exports a symbol called `Adapter` that implements the `Adapter` interface, the engine will pick it up and load it.